### PR TITLE
Using `Object.prototype.toString.call()` to check array type

### DIFF
--- a/src/infuse.js
+++ b/src/infuse.js
@@ -108,7 +108,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		}
 
 		// Override arg name with inject array values if present
-		if( cl.hasOwnProperty('inject') && toString.call(cl.inject) === '[object Array]' && cl.inject.length > 0)
+		if( cl.hasOwnProperty('inject') && Object.prototype.toString.call(cl.inject) === '[object Array]' && cl.inject.length > 0)
 		  inject = cl.inject;
 
 		var clStr = cl.toString().replace(STRIP_COMMENTS, '');


### PR DESCRIPTION
Using `Object.prototype.toString.call()` to check array type instead of `toString.call()`. The latter, taken from lodash, doesn't work in IE! The former is taken from the recommended polyfill on [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray).

Sorry about that Romu, I imagine the MDN polyfill will have better support.
