### PR TITLE
Add throwOnMissing option

### DIFF
--- a/src/infuse.js
+++ b/src/infuse.js
@@ -195,11 +195,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                     }
                 }
             }
-            if (this.throwOnMissing) {
-                throw new Error("Missing value '" + value + "'");
-            } else {
-                return undefined;
-            }
+            return undefined;
         },
 
         getValue: function(prop) {

--- a/src/infuse.js
+++ b/src/infuse.js
@@ -100,6 +100,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         this.mappings = {};
         this.parent = null;
         this.strictMode = false;
+        this.throwOnMissing = true;
     };
 
     infuse.getDependencies = function(cl) {

--- a/src/infuse.js
+++ b/src/infuse.js
@@ -195,7 +195,11 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                     }
                 }
             }
-            return undefined;
+            if (this.throwOnMissing) {
+                throw new Error("Missing value '" + value + "'");
+            } else {
+                return undefined;
+            }
         },
 
         getValue: function(prop) {
@@ -265,6 +269,9 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                     }
                     else {
                         // no mapping found
+                        if (this.throwOnMissing) {
+                            throw new Error(infuse.errors.NO_MAPPING_FOUND + " for dependency '" + name + "' when instantiating '" + TargetClass.name + "'");
+                        }
                         args.push(undefined);
                     }
                 }

--- a/src/infuse.js
+++ b/src/infuse.js
@@ -133,6 +133,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             var injector = new infuse.Injector();
             injector.parent = this;
             injector.strictMode = this.strictMode;
+            injector.throwOnMissing = this.throwOnMissing;
             return injector;
         },
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,7 +10,7 @@
 	<script type="text/javascript" src="lib/jasmine-1.2.0.rc3/jasmine-html.js"></script>
 
 	<!-- include source files here... -->
-	<script type="text/javascript" src="tests.spec.js"></script>
+	<script type="text/javascript" src="tests.Spec.js"></script>
 
 	<!-- include spec files here... -->
 	<script type="text/javascript" src="../src/infuse.js"></script>

--- a/tests/tests.Spec.js
+++ b/tests/tests.Spec.js
@@ -471,19 +471,15 @@ describe("infuse.js", function () {
 		injector.mapValue("p1", p1);
 		injector.mapValue("p2", p2);
 		injector.mapValue("p3", p3);
-		var FooClass = function(p1, p2, p3, p4, p5){
+		var FooClass = function(p1, p2, p3){
 			this.param1 = p1;
 			this.param2 = p2;
 			this.param3 = p3;
-			this.param4 = p4;
-			this.param5 = p5;
 		};
-		var foo = injector.createInstance(FooClass, null, undefined, "forced");
+		var foo = injector.createInstance(FooClass, null, "forced", undefined);
 		expect(foo.param1).toEqual(p1);
-		expect(foo.param2).toEqual(p2);
-		expect(foo.param3).toEqual("forced");
-		expect(foo.param4).toBeUndefined();
-		expect(foo.param5).toBeUndefined();
+		expect(foo.param2).toEqual("forced");
+		expect(foo.param3).toEqual(p3);
 	});
 
 	it("create instance with constructor mapping and inheritance", function () {
@@ -1093,8 +1089,8 @@ describe("infuse.js", function () {
 		expect(function(){childInjector.getValue("name")}).toThrow(infuse.errors.DEPENDENCIES_MISSING_IN_STRICT_MODE);
 	});
 
-	it("throwOnMissing is not enabled by default", function () {
-		expect(injector.throwOnMissing).toBeFalsy();
+	it("throwOnMissing is enabled by default", function () {
+		expect(injector.throwOnMissing).toBeTruthy();
 	});
 
 	describe("throwOnMissing", function() {

--- a/tests/tests.Spec.js
+++ b/tests/tests.Spec.js
@@ -1093,4 +1093,38 @@ describe("infuse.js", function () {
 		expect(function(){childInjector.getValue("name")}).toThrow(infuse.errors.DEPENDENCIES_MISSING_IN_STRICT_MODE);
 	});
 
+	it("throwOnMissing is not enabled by default", function () {
+		expect(injector.throwOnMissing).toBeFalsy();
+	});
+
+	describe("throwOnMissing", function() {
+
+		function getErrorMessage(callback) {
+			try {
+				callback();
+			} catch (e) {
+				return e.message;
+			}
+		}
+
+		beforeEach(function() {
+			injector.throwOnMissing = true;
+			injector.mapClass("fooClass", function(missing){});
+		});
+
+		it("causes requesting a missing value to throw", function () {
+			expect(function(){injector.getValue("missing")}).toThrow();
+			expect(function(){injector.getValue("fooClass")}).toThrow();
+			expect(function(){injector.createInstance(function(missing) {})}).toThrow();
+		});
+
+		it("throws an error that describes the problem when instantiating", function() {
+			expect(getErrorMessage(function(){injector.getValue("fooClass")})).toContain("missing");
+			var instantiationError = getErrorMessage(function(){injector.createInstance(function customClassName(not_a_predefined_string){})});
+			expect(instantiationError).toContain("not_a_predefined_string");
+			expect(instantiationError).toContain("customClassName");
+		});
+
+	});
+
 });

--- a/tests/tests.Spec.js
+++ b/tests/tests.Spec.js
@@ -1125,6 +1125,12 @@ describe("infuse.js", function () {
 			expect(instantiationError).toContain("customClassName");
 		});
 
+		it("is inherited in child injectors", function() {
+			injector.throwOnMissing = false;
+			var childInjector = injector.createChild();
+			expect(childInjector.throwOnMissing).toBeFalsy();
+		});
+
 	});
 
 });


### PR DESCRIPTION
Adds an option to throw errors when attempting to instantiate.

ie:

```js
injector.mapValue("fooClass", function ClassName(missingDependency){});
injector.getValue("fooClass");
// Returns an instance, even though the dependency is missing

injector.throwOnMissing = true;
injector.getValue("fooClass");
// Throws exception so it is obvious we forgot to define `missingDependency`
```