### PR TITLE
Adds support for ES6/2015 classes via esprima.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Or install it with bower:
 
 	bower install infuse.js --save
 
+If you need ES6/ES2015 class support, include [esprima](https://github.com/jquery/esprima) too, from npm or bower:
+
+    npm install esprima
+	bower install esprima --save
+
 ## create injector
 
 	var injector = new infuse.Injector();

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Or install it with bower:
 
 If you need ES6/ES2015 class support, include [esprima](https://github.com/jquery/esprima) too, from npm or bower:
 
-    npm install esprima
+	npm install esprima
 	bower install esprima --save
 
 ## create injector

--- a/src/infuse.js
+++ b/src/infuse.js
@@ -169,7 +169,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                             spl = constructor.value
                                 .params
                                 .filter(function(param) { return param.type === "Identifier" })
-                                .map(param => param.name);
+                                .map(function(param) { return param.name; });
                         }
                     } else {
                         throw firstE;

--- a/src/infuse.js
+++ b/src/infuse.js
@@ -128,27 +128,20 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     };
 
     infuse.getEsprima = function() {
+        var esprima = false;
         try {
-            if (window.esprima) {
-                return window.esprima;
-            } else {
-                throw "no window.esprima";
-            }
-        } catch (e) {
-            try {
-                if (global.esprima) {
-                    return global.esprima;
-                } else {
-                    throw "no global.esprima";
-                }
-            } catch (e) {
-                try {
-                    return require("esprima");
-                } catch (e) {
-                    return false;
-                }
-            }
-        }
+            esprima = esprima || window.esprima;
+        } catch (e) {}
+
+        try {
+            esprima = esprima || global.esprima;
+        } catch (e) {}
+
+        try {
+            esprima = esprima || (typeof global !== "undefined" ? global : window).require("esprima");
+        } catch (e) {}
+
+        return esprima;
     }
 
     infuse.getDependenciesFromString = function(clStr) {
@@ -180,7 +173,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             } else {
                 if (/^class/.test(clStr)) {
                     console.log("infuse.js requires esprima to parse ES2015 classes.");
-                )
+                }
                 throw firstE;
             }
         }

--- a/src/infuse.js
+++ b/src/infuse.js
@@ -25,7 +25,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
     // regex from angular JS (https://github.com/angular/angular.js)
     var FN_ARGS = /^function\s*[^\(]*\(\s*([^\)]*)\)/m;
-    var FN_ARG_SPLIT = /,/;
+    var FN_ARG_SPLIT = /,\s*/;
     var FN_ARG = /^\s*(_?)(\S+?)\1\s*$/;
     var STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
 
@@ -116,8 +116,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         }
 
         var clStr = cl.toString().replace(STRIP_COMMENTS, '');
-        var argsFlat = clStr.match(FN_ARGS);
-        var spl = argsFlat[1].split(FN_ARG_SPLIT);
+        var spl = this.getDependenciesFromString(clStr);
 
         for (var i=0, l=spl.length; i<l; i++) {
             // Only override arg with non-falsey deps value at same key
@@ -126,6 +125,67 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         }
 
         return args;
+    };
+
+    infuse.getEsprima = function() {
+        try {
+            if (window.esprima) {
+                return window.esprima;
+            } else {
+                throw "no window.esprima";
+            }
+        } catch (e) {
+            try {
+                if (global.esprima) {
+                    return global.esprima;
+                } else {
+                    throw "no global.esprima";
+                }
+            } catch (e) {
+                try {
+                    return require("esprima");
+                } catch (e) {
+                    return false;
+                }
+            }
+        }
+    }
+
+    infuse.getDependenciesFromString = function(clStr) {
+        try {
+            var argsFlat = clStr.match(FN_ARGS);
+            var spl = argsFlat[1].split(FN_ARG_SPLIT);
+        } catch (firstE) {
+            var esprima = this.getEsprima();
+            if (esprima) {
+                try {
+                    var tree = esprima.parse(clStr);
+                    if (tree.body[0].type === "ClassDeclaration") {
+                        var classMethods = tree.body[0].body.body;
+                        var constructor = classMethods.filter(function(method) {
+                                return method.kind === "constructor"
+                            })[0];
+                        if (constructor) {
+                            spl = constructor.value
+                                .params
+                                .filter(function(param) { return param.type === "Identifier" })
+                                .map(param => param.name);
+                        }
+                    } else {
+                        throw firstE;
+                    }
+                } catch (e) {
+                    throw e;
+                }
+            } else {
+                if (/^class/.test(clStr)) {
+                    console.log("infuse.js requires esprima to parse ES2015 classes.");
+                )
+                throw firstE;
+            }
+        }
+
+        return spl;
     };
 
     infuse.Injector.prototype = {

--- a/tests/tests.Spec.js
+++ b/tests/tests.Spec.js
@@ -36,6 +36,10 @@ utils.inherit = function(target, obj) {
 	return subclass;
 };
 
+utils.getGlobal = function() {
+	return (typeof process === "undefined" ? window : global);
+}
+
 
 describe("infuse.js", function () {
 
@@ -1130,33 +1134,25 @@ describe("infuse.js", function () {
 	});
 
 	describe("getEsprima()", function() {
-		it("should return window.esprima if available", function() {
-			var oldEsprima = window.esprima;
-			window.esprima = {};
+		it("should return ${GLOBAL}.esprima if available", function() {
+			var oldEsprima = utils.getGlobal().esprima;
+			utils.getGlobal().esprima = {};
 
-			expect(infuse.getEsprima()).toBe(window.esprima);
+			expect(infuse.getEsprima()).toBe(utils.getGlobal().esprima);
 
-			window.esprima = oldEsprima;
-		});
-
-		it("should return global.esprima if available", function() {
-			var oldGlobal = window.global;
-			window.global = { esprima: {} };
-
-			expect(infuse.getEsprima()).toBe(window.global.esprima);
-
-			window.global = oldGlobal;
+			utils.getGlobal().esprima = oldEsprima;
 		});
 
 		it("should attempt to require() if not already available", function() {
 			var fakeEsprima = {};
-			var oldRequire = window.require;
-			window.require = jasmine.createSpy("require").andReturn(fakeEsprima);
+			var oldRequire = utils.getGlobal().require;
+			utils.getGlobal().require = jasmine.createSpy("require");
+			utils.getGlobal().require.andReturn(fakeEsprima);
 
 			expect(infuse.getEsprima()).toBe(fakeEsprima);
-			expect(window.require).toHaveBeenCalled();
+			expect(utils.getGlobal().require).toHaveBeenCalled();
 
-			window.require = oldRequire;
+			utils.getGlobal().require = oldRequire;
 		});
 
 		it("should not error if all of the above fail", function() {


### PR DESCRIPTION
Fixes #8 

I tried using a regex as discussed in #8 however I ended up tying myself in knots when I realised that the constructor didn't need to be the first function, as in:

```js
class Test {
    static foo(bar) {
        // someone being silly and calling something 'constructor' inside 
        // another function, just to really mess with your regex.
        var constructor = function() {};
        constructor();
    }

    constructor(baz, quux) {
    }
}
```

So the easiest option seems to be to use [esprima](https://github.com/jquery/esprima) to parse the class and just use it's syntax tree to get the parameter names. As not everyone needs ES2015 classes yet, I've made the method `getEsprima()` try to find esprima, but gracefully degrade if it is not installed, and also warn that esprima is required if it looks like you're trying to inject into a ES2015 class.


('david-byng' is my work account by the way, apologies for any confusion :) )